### PR TITLE
fix: prepare for changes when moving an object

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+1.0.11 (2022-10-19)
+------------------
+
+* Handle UDM REST API doing immediate moves (without redirects) for objects without subordinates.
+
 1.0.10 (2022-10-13)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,6 @@ setup(
     python_requires=">=3.6",
     scripts=["update_openapi_client"],
     url="https://github.com/univention/python-udm-rest-api-client",
-    version="1.0.10",
+    version="1.0.11",
     zip_safe=False,
 )

--- a/udm_rest_client/__init__.py
+++ b/udm_rest_client/__init__.py
@@ -36,4 +36,4 @@ __all__ = [
 ]
 __author__ = """Daniel Troeder"""
 __email__ = "troeder@univention.de"
-__version__ = "1.0.10"
+__version__ = "1.0.11"

--- a/udm_rest_client/base_http.py
+++ b/udm_rest_client/base_http.py
@@ -831,13 +831,16 @@ class UdmObject(BaseObject):
             )
         except APICommunicationError as exc:
             raise MoveError(f"Error moving {self} to {position!r}: [{exc.status}] {exc.reason}")
-        if status != 201:  # pragma: no cover
+        if status not in (200, 201, 202):  # pragma: no cover
             raise MoveError(
                 f"Error moving {self} to {position!r}:\nHTTP [{status}]\n"
                 f"response: {new_api_obj!r}\nheader: {header!r}'",
                 dn=self.dn,
                 module_name=self._udm_module.name,
             )
+
+        if status == 200:  # pragma: no cover
+            return new_api_obj
 
         udm_api_response = await self._follow_move_redirects(header["Location"], position)
 


### PR DESCRIPTION
Moving doesn't necessarily require a redirection loop but may respond
immediately with 200 (https://forge.univention.org/bugzilla/show_bug.cgi?id=55019).

The HTTP status code of the move operation is wrong: 201 CREATED should
be 202 ACCEPTED. Handle both status codes
(https://forge.univention.org/bugzilla/show_bug.cgi?id=55057)