### PR TITLE
Prefer "Accept": "application/hal+json" in `modules_list()` as it uses HAL elements

### DIFF
--- a/udm_rest_client/base_http.py
+++ b/udm_rest_client/base_http.py
@@ -294,9 +294,9 @@ class Session:
 
     async def get_json(self, url: str, **kwargs) -> Dict[str, Any]:
         request_kwargs = copy.deepcopy(kwargs)
-        request_kwargs.setdefault("headers", {}).update(
-            {"Accept": "application/json", self.request_id_header: self.request_id}
-        )
+        request_kwargs.setdefault("headers", {})
+        request_kwargs["headers"].setdefault("Accept", "application/json")
+        request_kwargs["headers"].setdefault(self.request_id_header, self.request_id)
         request_kwargs["auth"] = aiohttp.BasicAuth(
             self.openapi_client_config.username, self.openapi_client_config.password
         )

--- a/udm_rest_client/udm.py
+++ b/udm_rest_client/udm.py
@@ -213,7 +213,7 @@ class UDM:
         :rtype: list(str)
         """
         url = urljoin(f"{self.session.openapi_client_config.host}/", "navigation/")
-        body = await self.session.get_json(url)
+        body = await self.session.get_json(url, headers={"Accept": "application/hal+json; q=1, application/json; q=0.9"})
         return sorted(ot["name"] for ot in body["_links"]["udm:object-types"])
 
     async def unknown_modules(self) -> Sequence[str]:


### PR DESCRIPTION
Prefer "Accept": "application/hal+json" in `modules_list()` as it uses HAL elements.