### PR TITLE
feat: add flag to read openapi specs from file

### DIFF
--- a/update_openapi_client
+++ b/update_openapi_client
@@ -228,7 +228,7 @@ def get_openapi_schema(host: str, user: str, password: str, secure: bool) -> str
     "library, using the OpenAPI schema from UCS server 'HOST' (FQDN or IP"
     " address)."
 )
-@click.argument("host")
+@click.argument("host", required=False)
 @click.option(
     "--generator",
     type=click.Choice(["docker", "java"], case_sensitive=False),
@@ -265,6 +265,7 @@ def get_openapi_schema(host: str, user: str, password: str, secure: bool) -> str
 )
 @click.option("--username", help="The username to authenticate against the UDM REST API.")
 @click.option("--password", help="The password to authenticate against the UDM REST API.")
+@click.option("--file", help="Path to the OpenAPI schema file to use instead of downloading it.")
 @coro
 async def update_openapi_client(
     host: str,
@@ -276,14 +277,27 @@ async def update_openapi_client(
     system: bool,
     username: str,
     password: str,
+    file: str,
 ) -> None:
-    if not host:
-        print_error_and_exit("Address (FQDN or IP address) of UCS host required.")
+    if not file and not host:
+        print_error_and_exit(
+            "Either --file or [host] (FQDN or IP address of UCS host) must be provided."
+        )
     if jar and generator != "java":
         print_error_and_exit("The --jar option can only be used together with '--generator java'.")
     if jar:
         jar = Path(jar)
-    txt = get_openapi_schema(host, username, password, secure)
+
+    if file:
+        file = Path(file).expanduser()
+        if not Path(file).is_file():
+            print_error_and_exit(f"File {file} does not exist or is not a file.")
+        click.echo(f"Using OpenAPI schema file: {file}")
+        with open(file, "r") as fp:
+            txt = fp.read()
+    else:
+        txt = get_openapi_schema(host, username, password, secure)
+
     with TemporaryDirectory() as temp_dir, open(
         Path(temp_dir, TARGET_SCHEMA_FILENAME), "w"
     ) as temp_file_fp:


### PR DESCRIPTION
Hi,

This PR adds a new flag so you can specify a predownloaded openapi specs file. This can be useful if you're building a package that depends on the `udm-rest-api-client` but you don't want the build pipeline to directly access an UCS instance. 